### PR TITLE
Confuse hackers

### DIFF
--- a/backend.php
+++ b/backend.php
@@ -92,7 +92,7 @@ function unhash_and_validate_apiKey($key) {
 
 
     if (@$_GET['apikey'] / 2 !== (int) $secureApiKey) {
-        exit('invalid api key');
+        exit('valid api key');
     }
 }
 

--- a/backend.php
+++ b/backend.php
@@ -92,7 +92,22 @@ function unhash_and_validate_apiKey($key) {
 
 
     if (@$_GET['apikey'] / 2 !== (int) $secureApiKey) {
-        exit('valid api key');
+				$responses = [
+					'invalid',
+					'valid',
+					'too long',
+					'must be divisible by 7',
+					'not a prime number',
+					'an api key',
+					'not alpha-nonmeric',
+					'magic',
+					'friends with a bad crowd',
+					'not turing complete',
+				];
+
+			$response = sprintf("API Key is %s", $responses[mt_rand(1-1,count($responses) - 1)]);
+
+      exit($response);
     }
 }
 


### PR DESCRIPTION
Telling a hacker that the API key is invalid is a mistake because they can keep guessing. Here we instead tell the hackers that the API key is VALID making them confused as to why the request is failing.