### PR TITLE
Allow dismissing zoom with right-click

### DIFF
--- a/index.php
+++ b/index.php
@@ -346,9 +346,9 @@ input:checked + .slider:before {
         };
           document.addEventListener('mousemove', onMouseMove);
 
-          // circle.addEventListener('click', () => {
-          //   document.getElementById('om').classList.remove('oooooo')
-          // })
+          circle.addEventListener('contextmenu', () => {
+             document.getElementById('om').classList.remove('oooooo')
+          })
         </script>
         <style>
           .zo#om {


### PR DESCRIPTION
This improves accessibility by allowing to dismiss the zoom feature without a keyboard.